### PR TITLE
Adapt to nixpkgs-24.11

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -61,8 +61,8 @@ self: rec {
 
       hardware = {
         deviceTree.enabledOverlays = with builtins; concatLists (attrValues boardCfg.hardware.enabled);
-        opengl.enable = true;
-        opengl.extraPackages = [ self.packages.${pkgs.stdenv.buildPlatform.system}.libmali-valhall-g610 ];
+        graphics.enable = true;
+        graphics.extraPackages = [ self.packages.${pkgs.stdenv.buildPlatform.system}.libmali-valhall-g610 ];
         firmware = lib.mkForce (with pkgs; [
           self.packages.${pkgs.stdenv.buildPlatform.system}.orangepi-firmware
           self.packages.${pkgs.stdenv.buildPlatform.system}.mali-firmware-g610

--- a/packages/linux/xunlong.nix
+++ b/packages/linux/xunlong.nix
@@ -1,4 +1,4 @@
-{ linuxManualConfig, fetchFromGitHub, ... }: linuxManualConfig rec {
+{ linuxManualConfig, fetchFromGitHub, ubootTools, ... }: (linuxManualConfig rec {
   src = fetchFromGitHub {
     owner = "orangepi-xunlong";
     repo = "linux-orangepi";
@@ -10,4 +10,6 @@
   extraMeta.branch = "6.1";
   configfile = ./config/linux-${version}.config;
   allowImportFromDerivation = true;
-}
+}).overrideAttrs (old: {
+  nativeBuildInputs = old.nativeBuildInputs ++ [ ubootTools ];
+})


### PR DESCRIPTION
Rename config parameters and update Linux Kernel build. This makes it possible to build socle with nixpkgs-24.11