### PR TITLE
Forego stable branch

### DIFF
--- a/templates/orangepi-5x/flake.nix
+++ b/templates/orangepi-5x/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     socle = {
-      url = "github:dvdjv/socle/stable";
+      url = "github:dvdjv/socle";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
The stable branch was useful when there was no automated checks. Now it is time to remove it.